### PR TITLE
Revert "Bump werkzeug from 2.3.8 to 3.1.3"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -464,13 +464,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "2.3.8"
 description = "The comprehensive WSGI web application library."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 files = [
-    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
-    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+    {file = "werkzeug-2.3.8-py3-none-any.whl", hash = "sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748"},
+    {file = "werkzeug-2.3.8.tar.gz", hash = "sha256:554b257c74bbeb7a0d254160a4f8ffe185243f52a52035060b761ca62d977f03"},
 ]
 
 [package.dependencies]
@@ -482,4 +482,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "79d1704b77f15d505cfe6b11feeceb87f02daa0a9cd17b4fbf30ec9c89ff4c3f"
+content-hash = "a42351c250d667ac6b2c5907a38ec86d87de1415511f9dd29517ce93aadf31d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ psycopg2-binary = "^2.9.5"
 django-storages = "^1.13.1"
 django-clearcache = "^1.2.1"
 boto3 = "^1.35.90"
-Werkzeug = "^3.1.3"
+Werkzeug = "^2.2.2"
 
 
 [build-system]


### PR DESCRIPTION
Reverts jboolean/cwcom#60

breaks with error

```
 Unable to import module 'wsgi_handler': cannot import name 'url_encode' from 'werkzeug.urls' (/var/task/werkzeug/urls.py),
```